### PR TITLE
Issue #1 fix:  Variant consequence parsing removes required variants

### DIFF
--- a/R/wrangle.R
+++ b/R/wrangle.R
@@ -51,13 +51,14 @@ read_small_variants <- function(cvo_list){
 #' @export
 process_small_variant_data <- function(small_variant_df){
 
-  variant_consequences <- c("frameshift_variant", "inframe_deletion",
-                            "inframe_insertion", "missense_variant",
-                            "missense_variant:splice_region_variant",
-                            "splice_acceptor_variant", "splice_donor_variant",
-                            "splice_donor_variant:intron_variant", "start_lost",
-                            "stop_gained", "stop_gained:splice_region_variant",
-                            "stop_lost")
+  variant_consequences <- c("3_prime_UTR_variant",
+                            "5_prime_UTR_variant",
+                            "downstream_gene_variant",
+                            "intron_variant",
+                            "splice_region_variant:intron_variant",
+                            "splice_region_variant:synonymous_variant",
+                            "synonymous_variant",
+                            "upstream_gene_variant")
 
   updated_df <- small_variant_df %>%
     filter_consequences(variant_consequences) %>%
@@ -68,7 +69,8 @@ process_small_variant_data <- function(small_variant_df){
   return(updated_df)
 }
 
-#' Filters small variant data for specified variant consequences
+#' Filters small variant data for variant consequences. Removes
+#' any variant with a consequence matching the list of submitted consequences
 #'
 #' @param small_variant_df
 #' @param consequences
@@ -76,7 +78,8 @@ process_small_variant_data <- function(small_variant_df){
 #' @return data.frame
 #' @export
 filter_consequences <- function(small_variant_df, consequences){
-  filtered_df <- small_variant_df %>% dplyr::filter(consequence_s %in% consequences)
+  filtered_df <- small_variant_df %>%
+    dplyr::filter(!(consequence_s %in% consequences | is.na(consequence_s) | consequence_s == ""))
   return(filtered_df)
 }
 

--- a/man/filter_consequences.Rd
+++ b/man/filter_consequences.Rd
@@ -2,7 +2,8 @@
 % Please edit documentation in R/wrangle.R
 \name{filter_consequences}
 \alias{filter_consequences}
-\title{Filters small variant data for specified variant consequences}
+\title{Filters small variant data for variant consequences. Removes
+any variant with a consequence matching the list of submitted consequences}
 \usage{
 filter_consequences(small_variant_df, consequences)
 }
@@ -13,5 +14,6 @@ filter_consequences(small_variant_df, consequences)
 data.frame
 }
 \description{
-Filters small variant data for specified variant consequences
+Filters small variant data for variant consequences. Removes
+any variant with a consequence matching the list of submitted consequences
 }


### PR DESCRIPTION
Variant consequence filtering behaviour now excludes variants by specifying a list of unwanted consequences, instead of by means of inclusion of required consequences.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/tso500r/2)
<!-- Reviewable:end -->
